### PR TITLE
styles flash banner moves to base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,16 @@
 	</nav>
     </header>
     <div class="container">
+        {% with messages = get_flashed_messages() %}
+          {% if messages %}
+            {% for message in messages %}
+            <div class="alert alert-success mt-3" role="alert">{{ message }}</div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+
 	{% block content %}{% endblock %}		  
+
         {% if 'username' in session: %}
             <span class="text-muted">Logged in as: {{ session['display_name'] }}</span>
         {% endif %}

--- a/templates/find_item.html
+++ b/templates/find_item.html
@@ -3,13 +3,6 @@
 {% block content %}
     <h1>Update {{ field_name }}</h1>
     <h2>Enter Item Barcode</h2>
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        {% for message in messages %}
-          <span class=flashes>{{ message }}</span>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
     <form id="lookup-item" action="{{ url_for(get_input_function) }}" method="post">
 	<div class="form-group row">
             <label for="barcode" class="col-sm-2 col-form-label">Barcode</label>


### PR DESCRIPTION
closes #4 
closes #5 

Moves the banner for flashed messages into the base template to cut down on repetition. Styles the flashed message as a "success" banner. See attached screenshot.

<img width="1332" alt="flash_chnages" src="https://user-images.githubusercontent.com/1715042/48800308-6fa4df80-ecd7-11e8-8c97-60f47a15e1d9.png">
